### PR TITLE
Update Cgicc.cpp

### DIFF
--- a/cgicc/Cgicc.cpp
+++ b/cgicc/Cgicc.cpp
@@ -324,11 +324,11 @@ cgicc::Cgicc::findEntries(const std::string& param,
   result.clear();
 
   if(byName) {
-    copy_if(fFormData.begin(), fFormData.end(), 
+    cgicc::copy_if(fFormData.begin(), fFormData.end(), 
 	    std::back_inserter(result),FE_nameCompare(param));
   }
   else {
-    copy_if(fFormData.begin(), fFormData.end(), 
+    cgicc::copy_if(fFormData.begin(), fFormData.end(), 
 	    std::back_inserter(result), FE_valueCompare(param));
   }
 


### PR DESCRIPTION
newer compilers define copy_if from std:: which clashes with copy_if from cgicc - namespace needs to be specified.